### PR TITLE
[BugFix] For `g:fuf_reuseWindow = 0`, force create a new window on split / vsplit / tab open type

### DIFF
--- a/autoload/fuf.vim
+++ b/autoload/fuf.vim
@@ -142,10 +142,10 @@ function fuf#openBuffer(bufNr, mode, reuse)
     return
   endif
   execute printf({
-        \   s:OPEN_TYPE_CURRENT : '%sbuffer'          ,
-        \   s:OPEN_TYPE_SPLIT   : '%ssbuffer'         ,
-        \   s:OPEN_TYPE_VSPLIT  : 'vertical %ssbuffer',
-        \   s:OPEN_TYPE_TAB     : 'tab %ssbuffer'     ,
+        \   s:OPEN_TYPE_CURRENT : '%sbuffer'         ,
+        \   s:OPEN_TYPE_SPLIT   : 'split | %sbuffer' ,
+        \   s:OPEN_TYPE_VSPLIT  : 'vsplit | %sbuffer',
+        \   s:OPEN_TYPE_TAB     : 'tabe | %sbuffer'  ,
         \ }[a:mode], a:bufNr)
 endfunction
 

--- a/autoload/fuf.vim
+++ b/autoload/fuf.vim
@@ -141,6 +141,9 @@ function fuf#openBuffer(bufNr, mode, reuse)
         \         l9#moveToBufferWindowInOtherTabpage(a:bufNr)))
     return
   endif
+  if exists('s:currentWin') && type(s:currentWin) == v:t_number
+    exec s:currentWin . 'wincmd w'
+  endif
   execute printf({
         \   s:OPEN_TYPE_CURRENT : '%sbuffer'         ,
         \   s:OPEN_TYPE_SPLIT   : 'split | %sbuffer' ,
@@ -378,6 +381,7 @@ function fuf#launch(modeName, initialPattern, partialMatching)
   endif
   call l9#tempvariables#setList(s:TEMP_VARIABLES_GROUP, s:oneTimeVariables)
   let s:oneTimeVariables = []
+  let s:currentWin = winnr()
   call s:activateFufBuffer()
   augroup FufLocal
     autocmd!
@@ -883,6 +887,9 @@ function s:handlerBase.onInsertLeave()
   if exists('self.reservedMode')
     call l9#tempvariables#setList(s:TEMP_VARIABLES_GROUP, tempVars)
     call fuf#launch(self.reservedMode, self.lastPattern, self.partialMatching)
+  endif
+  if exists('s:currentWin')
+    unlet s:currentWin
   endif
 endfunction
 

--- a/autoload/fuf.vim
+++ b/autoload/fuf.vim
@@ -141,9 +141,6 @@ function fuf#openBuffer(bufNr, mode, reuse)
         \         l9#moveToBufferWindowInOtherTabpage(a:bufNr)))
     return
   endif
-  if exists('s:currentWin') && type(s:currentWin) == v:t_number
-    exec s:currentWin . 'wincmd w'
-  endif
   execute printf({
         \   s:OPEN_TYPE_CURRENT : '%sbuffer'         ,
         \   s:OPEN_TYPE_SPLIT   : 'split | %sbuffer' ,
@@ -878,6 +875,12 @@ function s:handlerBase.onInsertLeave()
   call s:deactivateFufBuffer()
   call fuf#saveDataFile(self.getModeName(), 'stats', self.stats)
   execute self.windowRestoringCommand
+  if exists('s:currentWin') 
+    if type(s:currentWin) == v:t_number
+      exec s:currentWin . 'wincmd w'
+      unlet s:currentWin
+    endif
+  endif
   let fOpen = exists('s:reservedCommand')
   if fOpen
     call self.onOpen(s:reservedCommand[0], s:reservedCommand[1])
@@ -887,9 +890,6 @@ function s:handlerBase.onInsertLeave()
   if exists('self.reservedMode')
     call l9#tempvariables#setList(s:TEMP_VARIABLES_GROUP, tempVars)
     call fuf#launch(self.reservedMode, self.lastPattern, self.partialMatching)
-  endif
-  if exists('s:currentWin')
-    unlet s:currentWin
   endif
 endfunction
 


### PR DESCRIPTION
On `FufBuffer` -> split / vsplit / tab open type, now it does `:sbuffer`;
however, it tries to switch to the existing buffer window (if not found, it creates a new window, then).

If `g:fuf_reuseWindow = 0`, expected to open a new window always,
it should create a new window first (`:split`, `:vsplit`, `:tabe`) before loading the buffer by `:buffer`.